### PR TITLE
Update crossbeam-channel dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ repository = "https://github.com/xacrimon/uvth"
 documentation = "https://docs.rs/uvth"
 
 [dependencies]
-crossbeam-channel = "0.3.9"
+crossbeam-channel = "0.4"
 log = "0.4.8"
 num_cpus = "1.10.1"


### PR DESCRIPTION
From 0.3.9 to 0.4 (0.4.4 currently)

The aim is to try and reduce duplicates in Veloren, I've confirmed that this builds correctly but have not checked anything beyond building.